### PR TITLE
Use pass through proxy response instead of redirect

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,15 +102,21 @@ function pretty(baton) {
 }
 
 /**
- * Redirect to shields.io to serve the badge image.
+ * Proxy response from shields.io to serve the badge image.
  *
  * @param  {Reply} reply
  * @return {function}
  */
-function redirect(reply) {
+function proxy(reply) {
   return function(baton) {
     let badgeUrl = `${SHIELDS_URL}/${baton.label}-${baton.value}-brightgreen.${baton.extension}`
-    reply.redirect(badgeUrl)
+    reply.proxy({
+      uri: badgeUrl,
+      passThrough: true,
+      onResponse: function(error, res, request, reply, settings, ttl) {
+        reply(res).header('X-Uri', badgeUrl)
+      }
+    })
   }
 }
 
@@ -128,8 +134,8 @@ function badgeHandler(req, reply) {
   .then(fetch)
   .then(compressed)
   .then(pretty)
-  .then(redirect(reply))
-  .catch(redirect(reply))
+  .then(proxy(reply))
+  .catch(proxy(reply))
 }
 
 /** Configure & start the server. */

--- a/test.js
+++ b/test.js
@@ -20,8 +20,8 @@ describe('http://img.badgesize.io', () => {
       method: 'GET',
       url: '/baxterthehacker/public-repo/master/README.md.svg'
     }).then((res) => {
-      expect(res.statusCode).to.equal(302)
-      expect(res.headers.location).to.equal(`${SHIELDS_URL}/size-14 B-brightgreen.svg`)
+      expect(res.statusCode).to.equal(200)
+      expect(res.headers['x-uri']).to.equal(`${SHIELDS_URL}/size-14 B-brightgreen.svg`)
     })
   })
 
@@ -30,8 +30,8 @@ describe('http://img.badgesize.io', () => {
       method: 'GET',
       url: '/baxterthehacker/public-repo/master/README.md.svg?compression=gzip'
     }).then((res) => {
-      expect(res.statusCode).to.equal(302)
-      expect(res.headers.location).to.equal(`${SHIELDS_URL}/gzip size-34 B-brightgreen.svg`)
+      expect(res.statusCode).to.equal(200)
+      expect(res.headers['x-uri']).to.equal(`${SHIELDS_URL}/gzip size-34 B-brightgreen.svg`)
     })
   })
 
@@ -40,8 +40,8 @@ describe('http://img.badgesize.io', () => {
       method: 'GET',
       url: '/baxterthehacker/public-repo/changes/README.md.svg'
     }).then((res) => {
-      expect(res.statusCode).to.equal(302)
-      expect(res.headers.location).to.equal(`${SHIELDS_URL}/size-12 B-brightgreen.svg`)
+      expect(res.statusCode).to.equal(200)
+      expect(res.headers['x-uri']).to.equal(`${SHIELDS_URL}/size-12 B-brightgreen.svg`)
     })
   })
 
@@ -50,8 +50,8 @@ describe('http://img.badgesize.io', () => {
       method: 'GET',
       url: '/baxterthehacker/public-repo/changes/README.md.png'
     }).then((res) => {
-      expect(res.statusCode).to.equal(302)
-      expect(res.headers.location).to.equal(`${SHIELDS_URL}/size-12 B-brightgreen.png`)
+      expect(res.statusCode).to.equal(200)
+      expect(res.headers['x-uri']).to.equal(`${SHIELDS_URL}/size-12 B-brightgreen.png`)
     })
   })
 
@@ -60,8 +60,8 @@ describe('http://img.badgesize.io', () => {
       method: 'GET',
       url: '/baxterthehacker/public-repo/changes/README.md'
     }).then((res) => {
-      expect(res.statusCode).to.equal(302)
-      expect(res.headers.location).to.equal(`${SHIELDS_URL}/size-12 B-brightgreen.svg`)
+      expect(res.statusCode).to.equal(200)
+      expect(res.headers['x-uri']).to.equal(`${SHIELDS_URL}/size-12 B-brightgreen.svg`)
     })
   })
 
@@ -70,8 +70,8 @@ describe('http://img.badgesize.io', () => {
       method: 'GET',
       url: '/baxterthehacker/public-repo/master/README.md?label=taille'
     }).then((res) => {
-      expect(res.statusCode).to.equal(302)
-      expect(res.headers.location).to.equal(`${SHIELDS_URL}/taille-14 B-brightgreen.svg`)
+      expect(res.statusCode).to.equal(200)
+      expect(res.headers['x-uri']).to.equal(`${SHIELDS_URL}/taille-14 B-brightgreen.svg`)
     })
   })
 
@@ -82,8 +82,8 @@ describe('http://img.badgesize.io', () => {
         method: 'GET',
         url: '/non-sense/query'
       }).then((res) => {
-        expect(res.statusCode).to.equal(302)
-        expect(res.headers.location).to.equal(`${SHIELDS_URL}/size-unknown-brightgreen.svg`)
+        expect(res.statusCode).to.equal(200)
+        expect(res.headers['x-uri']).to.equal(`${SHIELDS_URL}/size-unknown-brightgreen.svg`)
       })
     })
 


### PR DESCRIPTION
Right now, the reply returns a 302 redirect that gets cached by Github's camo (and the browser when used from the API). That means that the badge never changes from the first shields.io URL it redirected to. This fix proxies the reply through the server.