### PR TITLE
:lipstick: use micro instead of hapi

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,7 @@
 {
   "extends": "ngryman",
-  "parser": "babel-eslint"
+  "parser": "babel-eslint",
+  "rules": {
+    "handle-callback-err": 0
+  }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "lint": "eslint *.js",
     "unit": "nyc ava",
-    "start": "node index.js",
+    "start": "micro index.js -p ${PORT:=3000} --no-babel",
     "test": "npm run lint -s && npm run unit -s",
     "dev": "npm run unit -- --watch",
     "coverage": "nyc report --reporter=text-lcov | codecov",
@@ -39,20 +39,20 @@
     "weight"
   ],
   "dependencies": {
-    "got": "^3.3.1",
+    "got": "^6.3.0",
     "gzip-size": "^2.0.3",
-    "hapi": "^8.8.0",
+    "micro": "^4.1.1",
     "pretty-bytes": "^2.0.1"
   },
   "devDependencies": {
     "ava": "^0.15.2",
+    "babel": "^5.8.38",
     "babel-eslint": "^6.1.2",
     "codecov.io": "^0.1.6",
     "eslint": "^3.1.0",
     "eslint-config-ngryman": "^1.1.0",
-    "inject-then": "^2.0.0",
     "nyc": "^7.0.0",
-    "onchange": "^1.1.0",
-    "pre-commit": "^1.1.3"
+    "pre-commit": "^1.1.3",
+    "test-listen": "^1.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,121 +1,83 @@
 import test from 'ava'
-import injectThen from 'inject-then'
-import server from './'
+import micro from 'micro'
+import got from 'got'
+import listen from 'test-listen'
+import 'babel/register'
+import badgeSize from './'
 
 const SHIELDS_URL = 'https://img.shields.io/badge'
 
-test.before.cb(t => {
-  server.register(injectThen, t.end)
+function request(t, path) {
+  return got(`${t.context.url}${path}`, {
+    followRedirect: false
+  })
+}
+
+function assert(t, res, pathname) {
+  t.is(res.statusCode, 303)
+  t.is(res.headers.location, `${SHIELDS_URL}${encodeURI(pathname)}`)
+}
+
+test.beforeEach(async t => {
+  t.context.server = micro(badgeSize)
+  t.context.url = await listen(t.context.server)
 })
 
-test.after(() => server.stop())
+test.afterEach.cb(t => {
+  t.context.server.close(t.end)
+})
 
 test('redirect to shields.io', async t => {
-  const res = await server.injectThen({
-    method: 'GET',
-    url: '/baxterthehacker/public-repo/master/README.md.svg'
-  })
-
-  t.is(res.statusCode, 302)
-  t.is(res.headers.location, `${SHIELDS_URL}/size-14 B-brightgreen.svg`)
+  const res = await request(t, '/baxterthehacker/public-repo/master/README.md.svg')
+  assert(t, res, '/size-14 B-brightgreen.svg')
 })
 
 test('accept gzip compression', async t => {
-  const res = await server.injectThen({
-    method: 'GET',
-    url: '/baxterthehacker/public-repo/master/README.md.svg?compression=gzip'
-  })
-
-  t.is(res.statusCode, 302)
-  t.is(res.headers.location, `${SHIELDS_URL}/gzip size-34 B-brightgreen.svg`)
+  const res = await request(t, '/baxterthehacker/public-repo/master/README.md.svg?compression=gzip')
+  assert(t, res, '/gzip size-34 B-brightgreen.svg')
 })
 
 test('accept other branch names', async t => {
-  const res = await server.injectThen({
-    method: 'GET',
-    url: '/baxterthehacker/public-repo/changes/README.md.svg'
-  })
-
-  t.is(res.statusCode, 302)
-  t.is(res.headers.location, `${SHIELDS_URL}/size-12 B-brightgreen.svg`)
+  const res = await request(t, '/baxterthehacker/public-repo/changes/README.md.svg')
+  assert(t, res, '/size-12 B-brightgreen.svg')
 })
 
 test('allow other image extensions', async t => {
-  const res = await server.injectThen({
-    method: 'GET',
-    url: '/baxterthehacker/public-repo/changes/README.md.png'
-  })
-
-  t.is(res.statusCode, 302)
-  t.is(res.headers.location, `${SHIELDS_URL}/size-12 B-brightgreen.png`)
+  const res = await request(t, '/baxterthehacker/public-repo/changes/README.md.png')
+  assert(t, res, '/size-12 B-brightgreen.png')
 })
 
 test('default to svg if no comprehensible extension is found', async t => {
-  const res = await server.injectThen({
-    method: 'GET',
-    url: '/baxterthehacker/public-repo/changes/README.md'
-  })
-
-  t.is(res.statusCode, 302)
-  t.is(res.headers.location, `${SHIELDS_URL}/size-12 B-brightgreen.svg`)
+  const res = await request(t, '/baxterthehacker/public-repo/changes/README.md')
+  assert(t, res, '/size-12 B-brightgreen.svg')
 })
 
 test('accept a custom label', async t => {
-  const res = await server.injectThen({
-    method: 'GET',
-    url: '/baxterthehacker/public-repo/master/README.md?label=taille'
-  })
-
-  t.is(res.statusCode, 302)
-  t.is(res.headers.location, `${SHIELDS_URL}/taille-14 B-brightgreen.svg`)
+  const res = await request(t, '/baxterthehacker/public-repo/master/README.md?label=taille')
+  assert(t, res, '/taille-14 B-brightgreen.svg')
 })
 
 test('accept a custom color', async t => {
-  const res = await server.injectThen({
-    method: 'GET',
-    url: '/baxterthehacker/public-repo/master/README.md?color=bada55'
-  })
-
-  t.is(res.statusCode, 302)
-  t.is(res.headers.location, `${SHIELDS_URL}/size-14 B-bada55.svg`)
+  const res = await request(t, '/baxterthehacker/public-repo/master/README.md?color=bada55')
+  assert(t, res, '/size-14 B-bada55.svg')
 })
 
 test('accept a custom style', async t => {
-  const res = await server.injectThen({
-    method: 'GET',
-    url: '/baxterthehacker/public-repo/master/README.md?style=flat'
-  })
-
-  t.is(res.statusCode, 302)
-  t.is(res.headers.location, `${SHIELDS_URL}/size-14 B-brightgreen.svg?style=flat`)
+  const res = await request(t, '/baxterthehacker/public-repo/master/README.md?style=flat')
+  assert(t, res, '/size-14 B-brightgreen.svg?style=flat')
 })
 
 test('reject empty paths', async t => {
-  const res = await server.injectThen({
-    method: 'GET',
-    url: '/'
-  })
-
-  t.is(res.statusCode, 302)
-  t.is(res.headers.location, `${SHIELDS_URL}/size-empty path-lightgrey.svg`)
+  const res = await request(t, '/')
+  assert(t, res, '/size-empty path-lightgrey.svg')
 })
 
 test('reject invalid path', async t => {
-  const res = await server.injectThen({
-    method: 'GET',
-    url: '/non-sense/query'
-  })
-
-  t.is(res.statusCode, 302)
-  t.is(res.headers.location, `${SHIELDS_URL}/size-unknown path-lightgrey.svg`)
+  const res = await request(t, '/non-sense/query')
+  assert(t, res, '/size-unknown path-lightgrey.svg')
 })
 
 test('reject other types of compression', async t => {
-  const res = await server.injectThen({
-    method: 'GET',
-    url: '/baxterthehacker/public-repo/master/README.md.svg?compression=lzma'
-  })
-
-  t.is(res.statusCode, 302)
-  t.is(res.headers.location, `${SHIELDS_URL}/gzip size-unknown compression-lightgrey.svg`)
+  const res = await request(t, '/baxterthehacker/public-repo/master/README.md.svg?compression=lzma')
+  assert(t, res, '/gzip size-unknown compression-lightgrey.svg')
 })


### PR DESCRIPTION
Preety huge commit. I switched to micro as hapi is way too bloated for a micro-service.
I also use redirect again instead of proxying badge requests from shields.io. It was
originally done to avoi camo caching the image, but there is a way to force no cache,
so :+1: for load.