### PR TITLE
feat: Added brotli compression

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "weight"
   ],
   "dependencies": {
+    "brotli-size": "0.0.1",
     "got": "^6.5.0",
     "gzip-size": "^3.0.0",
     "micro": "^7.0.3",

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@ their builds to their users. But you can use it for any other purpose of course 
 :------------|:---------------------------------------------------------------------------------|
 Normal size  | ![](http://img.badgesize.io/ngryman/badge-size/master/index.js.svg)
 Gzipped size | ![](http://img.badgesize.io/ngryman/badge-size/master/index.js.svg?compression=gzip)
+Brotli size  | ![](http://img.badgesize.io/ngryman/badge-size/master/index.js.svg?compression=brotli)
 Custom label | ![](http://img.badgesize.io/ngryman/badge-size/master/index.js.svg?label=As_tiny_as)
 PNG format   | ![](http://img.badgesize.io/ngryman/badge-size/master/index.js.png)
 JPG format   | ![](http://img.badgesize.io/ngryman/badge-size/master/index.js.jpg)
@@ -56,14 +57,14 @@ Note that the branch name is mandatory.
 
 Optional image format. By default `svg` is used.
 
-#### `[?compression=gzip]`
+#### `[?compression=gzip|brotli]`
 
 Optional compression format to measure. It's useful if you want to advertise the *true* size your
-file would take on the wire, assuming the server has `gzip` compression enabled.
+file would take on the wire, assuming the server has `gzip` or `brotli` compression enabled.
 
 #### `[&label=string]`
 
-Optional text to display in the badge instead of *size* / *gzip size*.
+Optional text to display in the badge instead of *size* / *gzip size* / *brotli size*.
 
 #### `[&color=string]`
 

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ It works like any other badge service you may know and it's configurable in the 
 Here is the general pattern of a typical `badge-size` url:
 
 ```
-http://img.badgesize.io/:filepath[.svg|png|jpg][?compression=gzip][&label=string][&max=string][&softmax=string]
+http://img.badgesize.io/:filepath[.svg|png|jpg][?compression=gzip|brotli][&label=string][&max=string][&softmax=string]
 ```
 
 #### `:filepath`
@@ -110,11 +110,11 @@ http://img.badgesize.io/:filepath?max=100000&softmax=200000
 ## Contributors
 
 [//]: contributor-faces
-<a href="https://github.com/ngryman"><img src="https://avatars6.githubusercontent.com/u/892048?v=4" title="ngryman" width="80" height="80"></a>
-<a href="https://github.com/greenkeeperio-bot"><img src="https://avatars6.githubusercontent.com/u/14790466?v=3" title="greenkeeperio-bot" width="80" height="80"></a>
-<a href="https://github.com/nathancahill"><img src="https://avatars4.githubusercontent.com/u/1383872?v=4" title="nathancahill" width="80" height="80"></a>
-<a href="https://github.com/OliverJAsh"><img src="https://avatars6.githubusercontent.com/u/921609?v=4" title="OliverJAsh" width="80" height="80"></a>
-<a href="https://github.com/coopy"><img src="https://avatars6.githubusercontent.com/u/794843?v=4" title="coopy" width="80" height="80"></a>
+<a href="https://github.com/ngryman"><img src="https://avatars2.githubusercontent.com/u/892048?v=4" title="ngryman" width="80" height="80"></a>
+<a href="https://github.com/nathancahill"><img src="https://avatars0.githubusercontent.com/u/1383872?v=4" title="nathancahill" width="80" height="80"></a>
+<a href="https://github.com/OliverJAsh"><img src="https://avatars2.githubusercontent.com/u/921609?v=4" title="OliverJAsh" width="80" height="80"></a>
+<a href="https://github.com/coopy"><img src="https://avatars2.githubusercontent.com/u/794843?v=4" title="coopy" width="80" height="80"></a>
+<a href="https://github.com/hairmot"><img src="https://avatars2.githubusercontent.com/u/8102124?v=4" title="hairmot" width="80" height="80"></a>
 [//]: contributor-faces
 
 <sup>Generated with [contributors-faces](https://github.com/ngryman/contributor-faces).</sup>

--- a/test.js
+++ b/test.js
@@ -45,7 +45,7 @@ test('accept gzip compression', async t => {
 
 test('accept brotli compression', async t => {
   const res = await request(t, '/baxterthehacker/public-repo/master/README.md.svg?compression=brotli')
-  assert(t, res, '/brotli size-34 B-brightgreen.svg')
+  assert(t, res, '/brotli size-18 B-brightgreen.svg')
 })
 
 test('accept other branch names', async t => {
@@ -90,7 +90,7 @@ test('reject invalid path', async t => {
 
 test('reject other types of compression', async t => {
   const res = await request(t, '/baxterthehacker/public-repo/master/README.md.svg?compression=lzma')
-  assert(t, res, '/gzip size-unknown compression-lightgrey.svg')
+  assert(t, res, '/size-unknown compression-lightgrey.svg')
 })
 
 test('Size is valid', async t => {

--- a/test.js
+++ b/test.js
@@ -43,6 +43,11 @@ test('accept gzip compression', async t => {
   assert(t, res, '/gzip size-34 B-brightgreen.svg')
 })
 
+test('accept brotli compression', async t => {
+  const res = await request(t, '/baxterthehacker/public-repo/master/README.md.svg?compression=brotli')
+  assert(t, res, '/brotli size-34 B-brightgreen.svg')
+})
+
 test('accept other branch names', async t => {
   const res = await request(t, '/baxterthehacker/public-repo/changes/README.md.svg')
   assert(t, res, '/size-12 B-brightgreen.svg')


### PR DESCRIPTION
close #66

I deployed the fork on now.sh if you want to try it:

![](https://badge-size.now.sh/https://unpkg.com/popper.js/dist/popper.min.js?compression=brotli)
https://badge-size.now.sh/https://unpkg.com/popper.js/dist/popper.min.js?compression=brotli