### PR TITLE
Add badge to display install size

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# badge-size [![npm][npm-image]][npm-url] [![travis][travis-image]][travis-url]
+# badge-size [![npm][npm-image]][npm-url] [![install size](https://packagephobia.now.sh/badge?p=badge-size)](https://packagephobia.now.sh/result?p=badge-size) [![travis][travis-image]][travis-url]
 
 [npm-image]: https://img.shields.io/npm/v/badge-size.svg?style=flat
 [npm-url]: https://npmjs.org/package/badge-size


### PR DESCRIPTION
This adds a badge to the `README.md` file to display the install size of the npm package.