### PR TITLE
Fix unpkg.com head requests (#75)

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,6 +1,18 @@
 const got = require('got')
 
 /**
+ * Tell if we need the `identity` header.
+ *
+ * Cloudflare seems to return chunk encoded content if we specify this header
+ * for HEAD requests (#75).
+ *
+ * @param {object} baton
+ * @return {boolean}
+ */
+const needsIdentityHeader = (baton) =>
+  !baton.url.includes('unpkg.com')
+
+/**
  * Fetch file to stat from Github.
  *
  * @param {object} baton
@@ -8,9 +20,11 @@ const got = require('got')
 async function fetch(baton) {
   try {
     const res = await got[baton.compression ? 'get' : 'head'](baton.url, {
-      headers: {
-        'accept-encoding': 'identity'
-      }
+      headers: needsIdentityHeader(baton)
+        ? {
+          'accept-encoding': 'identity'
+        }
+        : undefined
     })
 
     baton.originalSize = Number(res.headers['content-length'])

--- a/test.js
+++ b/test.js
@@ -145,3 +145,8 @@ test('accept json format and differenciate original size from compressed size', 
   const res = await request(t, '/baxterthehacker/public-repo/master/README.md.json?compression=gzip')
   assertBody(t, res, { prettySize: '34 B', originalSize: 14, size: 34, color: '44cc11' })
 })
+
+test('works with HEAD request on Cloudflare (#75)', async t => {
+  const res = await request(t, '/https://unpkg.com/constate.json?style=flat-square')
+  assertBody(t, res, { prettySize: '323 B', originalSize: 323, size: 323, color: '44cc11' })
+})


### PR DESCRIPTION
Cloudflare seems to send chunk-encoded data when setting the `accept-encoding` to `identity` for `HEAD` request. This PR fixes that by not setting this header for if the request contains the `unpkg.com` domain which relies on Cloudflare.

This is the simpler approach I've found to resolve the issue.